### PR TITLE
Revise contradictory version positioning rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,8 +46,8 @@ accept any requests that do not specify a version number.
 - Use HTTP verbs (`GET`, `POST`, `PUT`, `DELETE`, etc.) to operate on the
 collections and elements.
 - You shouldn’t need to go deeper than `resource/identifier/resource`.
-- Put the version number at the base of your URL, for example
-`http://example.com/v1/path/to/resource`.
+- Put the version number immediately after the base api name in your URL, for example
+`http://example.com/api/v1/path/to/resource`.
 - URL v. header:
     - If it changes the logic you write to handle the response, put it in the
     URL.


### PR DESCRIPTION
The original rule to put the version as the base of your URL was directly contradicted by every single example in the rest of the document, so I revised the rule to say what I think it meant to.
